### PR TITLE
Added error message when permissions are missing

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -143,6 +143,7 @@ function handleMessages(msgCode) {
 // Handle toolbar button click
 function handleBrowserActionClicked() {
     if (activityPending) open('activity');
+    else browser.runtime.openOptionsPage();
 }
 
 // End activity

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -12,6 +12,7 @@ browser.storage.local.set({ 'tempDisabled': 0 });
 browser.runtime.onInstalled.addListener(handleInstalled);
 browser.tabs.onUpdated.addListener(checkTimer);
 browser.browserAction.onClicked.addListener(handleBrowserActionClicked);
+checkPermissions();
 
 // Check that alarm is valid
 async function checkTimer() {
@@ -157,4 +158,16 @@ function activityWaiting() {
     activityPending = true;
     browser.browserAction.setIcon({ path: 'icons/browserAction/active.gif' });
     browser.browserAction.setBadgeText({ text: ' ! ' });
+}
+
+// Checks that the required optional permissions are enabled
+async function checkPermissions() {
+    const settings = await browser.storage.local.get();
+    if (settings.notificationMode === 0) {
+        if (!(await browser.permissions.contains({ permissions: ['notifications'] }))) {
+            browser.tabs.create({
+                url: 'error/missingPermissions.html'
+            });
+        }
+    }
 }

--- a/firefox/error/missingPermissions.html
+++ b/firefox/error/missingPermissions.html
@@ -1,0 +1,32 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Action Required - Digital Eye Strain Prevention Tool</title>
+        <link rel="stylesheet" href="style.css">
+        <link rel="icon" type="image/png" href="../icons/icon-32.png">
+    </head>
+    <body>
+        <section class="wrapper">
+            <img src="../icons/icon-64.png" alt="Digital Eye Strain Prevention Tool">
+            <h2>Action Required</h2>
+            <p>The <i>Digital Eye Strain Prevention Tool</i> requires permission to create browser notifications. Please grant this permission or change your the add-on options to use a different notification mode.</p>
+            <div id="notGranted">
+                <button id="grantPermission">Grant Permission</button>
+                <br>
+                <button id="viewOptions">Open Options</button>
+            </div>
+            <div id="errorGranting" class="hidden">
+                The permission has still not been granted. Please try again.
+            </div>
+            <div id="granted" class="hidden">
+                <h3>You can now close this page</h3>
+            </div>
+        </section>
+        <script src="script.js"></script>
+    </body>
+</html>

--- a/firefox/error/script.js
+++ b/firefox/error/script.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https: //mozilla.org/MPL/2.0/. */
+
+function grantPermission() {
+    browser.permissions.request({ permissions: ['notifications'] }).then(updateUI);
+}
+
+function openOptions() {
+    browser.runtime.openOptionsPage();
+}
+
+function updateUI(granted) {
+    const grantedUI = document.getElementById('granted');
+    const notGrantedUI = document.getElementById('notGranted');
+    const errorGranting = document.getElementById('errorGranting');
+
+    if (granted) {
+        grantedUI.classList.remove('hidden');
+        notGrantedUI.classList.add('hidden');
+        errorGranting.classList.add('hidden');
+    } else {
+        errorGranting.classList.remove('hidden');
+    }
+}
+
+document.getElementById('grantPermission').addEventListener('click', grantPermission);
+document.getElementById('viewOptions').addEventListener('click', openOptions);

--- a/firefox/error/style.css
+++ b/firefox/error/style.css
@@ -1,0 +1,58 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https: //mozilla.org/MPL/2.0/. */
+
+body {
+    background: #262626;
+}
+
+.hidden {
+    display: none !important;
+}
+
+.wrapper {
+    background: white;
+    width: 90%;
+    max-width: 500px;
+    margin: auto;
+    box-sizing: border-box;
+    padding: 1em 2em;
+    text-align: center;
+    border-radius: 5px;
+    margin-top: 5em;
+}
+
+p {
+    text-align: left;
+}
+
+button {
+    border: none;
+    padding: 10px 30px;
+    font-size: 14pt;
+    font-weight: bold;
+    border-radius: 100px;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: ease all 0.5s;
+    box-shadow: 0 2px 4px 2px hsla(0,0%,0%,0.08);
+}
+
+#grantPermission {
+    color: white;
+    background-color: #00CC66;
+    background-image: linear-gradient(#00CC66,#00994D);
+}
+
+#viewOptions {
+    margin-top: 0.5em;
+    color: white;
+    background-color: #48AAD7;
+    background-image: linear-gradient(#48AAD7,#0E8BAF);
+    font-size: 80%;
+}
+
+#errorGranting {
+    color: red;
+    margin-top: 0.5em;
+}

--- a/firefox/popup/style.css
+++ b/firefox/popup/style.css
@@ -113,7 +113,7 @@ section p {
 }
 
 /* Override hover effect for non-recommended option */
-.button.hidden: hover, .button: disabled: hover {
+.button.hidden:hover, .button:disabled:hover {
     filter: none !important;
 }
 


### PR DESCRIPTION
This pull request will open an error tab when the browser starts if the user is missing the notification permission. Closes #18.

This pull request also allows the user to open the add-on options if there is no activity pending. Closes #25.